### PR TITLE
option for removing modal on hide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Meteor.startup(function(){
     modalDialogClass: "share-modal-dialog", //optional
     modalBodyClass: "share-modal-body", //optional
     modalFooterClass: "share-modal-footer",//optional
+    removeOnHide: true, //optional. If this is true, modal will be removed from DOM upon hiding
     buttons: {
       "cancel": {
         class: 'btn-danger',

--- a/lib/reactive-modal.js
+++ b/lib/reactive-modal.js
@@ -53,6 +53,13 @@ ReactiveModal.initDialog = function (info){
   info.hide = function(){
     modalTarget.modal('hide');
   }
+
+  if (info.removeOnHide) {
+    modalTarget.on('hidden.bs.modal', function() {
+      $(this).remove();
+    });
+  }
+
   info.modalTarget = modalTarget;
   return info;
 };


### PR DESCRIPTION
Currently, modals stay in the DOM, which causes some conflicts with the way Meteor works with inputs. 
I open a modal with some data that I fill from a template, based on  Session.get("selectedId"),
Template.modal.name = function() {
var _user = Users.findOne({_id: ession.get("selectedId")});
return _user && _user.name;
}

I change the input in the form, save it which closes the modal.
I open the same modal again, with different ID in selectedId, but the input won't be refreshed. Also, the modal stays in the dom for no reason, it's just easier and cleaner to start up a new modal each time we run this function. I don't want to change the default behavior, so my pull request only adds a possibility to do just that. 
