### PR TITLE
Using new helpers assign convention. Fixes #14.

### DIFF
--- a/lib/reactive-modal.js
+++ b/lib/reactive-modal.js
@@ -4,24 +4,25 @@ ReactiveModal = function(){
   this.buttons = {};
 };
 // _.extend(ReactiveModal.prototype, EV.prototype);
-Template._reactiveModal.class = function(){
-  var att;
-  if(this.class){
-    att = 'btn ' + this.class;
+Template._reactiveModal.helpers({
+  class: function(){
+    var att;
+    if(this.class){
+      att = 'btn ' + this.class;
+    }
+    return att;
+  },
+  dismiss: function(){
+    if(this.button.closeModalOnClick){
+      return "modal";
+    }
+  },
+  arrayify: function(obj){
+    result = [];
+    for (var key in obj) result.push({name:key,button:obj[key]});
+    return result;
   }
-  return att;
-}
-Template._reactiveModal.dismiss = function(){
-  if(this.button.closeModalOnClick){
-    return "modal";
-  }
-}
-
-Template._reactiveModal.arrayify = function(obj){
-  result = [];
-  for (var key in obj) result.push({name:key,button:obj[key]});
-  return result;
-}
+});
 
 Template._reactiveModal.events({
   'click .modal-footer .reactive-modal-btn.btn': function(e){


### PR DESCRIPTION
Fixes Blaze templating warnings from not assigning through `Template.theTemplate.helpers({});` such as:

```
(blaze.js:67) Warning: Assigning helper with `Template._reactiveModal.arrayify = ...` is deprecated.
Use `Template._reactiveModal.helpers(...)` instead 
```
